### PR TITLE
some small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ For example, a Jekyll project might define the following tasks in
       "label": "Build",
       "type": "shell",
       "command": "bundle exec jekyll build",
-      "group": "build",
       "problemMatcher": ["$jekyll-error", "$jekyll-warning"],
       "group": {
         "kind": "build",

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
         "severity": "warning",
         "fileLocation": "relative",
         "pattern": {
-          "regexp": "^\\s*Liquid Warning: Liquid (?:syntax )?error \\(line (\\d+)\\): (.+) in (.+)$",
-          "line": 1,
-          "message": 2,
-          "file": 3
+          "regexp": "^\\s*Liquid Warning: Liquid (?:syntax )?error \\((.*) line ([0-9]{1,})\\): (.*)$",                
+          "line": 2,
+          "message": 3,
+          "file": 1
         }
       },
       {
@@ -41,10 +41,10 @@
         "severity": "error",
         "fileLocation": "relative",
         "pattern": {
-          "regexp": "^\\s*Liquid Exception: Liquid (?:syntax )?error \\(line (\\d+)\\): (.+) in (.+)$",
-          "line": 1,
-          "message": 2,
-          "file": 3
+          "regexp": "^\\s*Liquid Exception: Liquid (?:syntax )?error \\((.*) line ([0-9]{1,})\\): (.*)$",                
+          "line": 2,
+          "message": 3,
+          "file": 1
         }
       },
       {

--- a/package.json
+++ b/package.json
@@ -51,14 +51,18 @@
         "name": "jekyll-warning-watch",
         "base": "$jekyll-warning",
         "background": {
-          "activeOnStart": true
+          "activeOnStart": true,
+          "beginsPattern": "^\\s+Regenerating:\\s\\d{1,4}\\sfile\\(s\\)\\schanged\\sat\\s[12][0-9]{3}-[01][0-9]-[0123][0-9]\\s.*$",
+          "endsPattern": "^\\s+\\.\\.\\.done\\sin\\s\\d{1,}\\.\\d{4,}\\sseconds\\..*$|^\\s+Error:\\sRun\\sjekyll\\sbuild\\s--trace\\sfor\\smore\\sinformation\\..*$"
         }
       },
       {
         "name": "jekyll-error-watch",
         "base": "$jekyll-error",
         "background": {
-          "activeOnStart": true
+          "activeOnStart": true,
+          "beginsPattern": "^\\s+Regenerating:\\s\\d{1,4}\\sfile\\(s\\)\\schanged\\sat\\s[12][0-9]{3}-[01][0-9]-[0123][0-9]\\s.*$",
+          "endsPattern": "^\\s+\\.\\.\\.done\\sin\\s\\d{1,}\\.\\d{4,}\\sseconds\\..*$|^\\s+Error:\\sRun\\sjekyll\\sbuild\\s--trace\\sfor\\smore\\sinformation\\..*$"
         }
       }
     ]


### PR DESCRIPTION
Hi,

when trying to use the extension I detected some issues, one of it being an error message from VS code "Task Serve is a background task but uses a problem matcher without a background pattern", and the other was the example tasks.json, where the property 'group' was given twice.

The second commit was to make the problemMatcher work with my Jekyll 4.0.0, where the error messages seem to be different to what the extension was designed for.

I tested the config on my VS Code, but I didn't create a new extension to check if the extension changes are ok (I hope they are).

Looking forward for your feedback on this.

Regards
Harald